### PR TITLE
chore: update workflows to remove corepack references

### DIFF
--- a/.github/workflows/release-development.yaml
+++ b/.github/workflows/release-development.yaml
@@ -29,10 +29,10 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2
 
       - name: Install dependencies
-        run: corepack pnpm install
+        run: pnpm install
 
       - name: Install roblox-ts
-        run: corepack pnpm add roblox-ts
+        run: pnpm add roblox-ts
 
       - name: Setup Rokit
         uses: CompeyDev/setup-rokit@d49be92bd9502180218c3f43e7988faa945217b0 # v0.1.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,13 +32,13 @@ jobs:
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2
 
       - name: Install dependencies
-        run: corepack pnpm install
+        run: pnpm install
 
       - name: Install roblox-ts
-        run: corepack pnpm add roblox-ts
+        run: pnpm add roblox-ts
 
       - name: Compile
-        run: corepack pnpm prod:build --verbose
+        run: pnpm prod:build --verbose
 
       - name: Build project
         run: rojo build ./build.project.json --output place.rbxlx

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-corepack pnpm dlx commitlint --edit "$1"
+pnpm dlx commitlint --edit "$1"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 # matches only the package-lock.json inside project directory
-npx git-pull-run --pattern "pnpm-lock.yaml" --command "corepack pnpm install"
+npx git-pull-run --pattern "pnpm-lock.yaml" --command "pnpm install"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-corepack pnpm lint-staged
+pnpm lint-staged

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,10 +29,12 @@
 	"npm.packageManager": "pnpm",
 
 	// Mise Tools settings
+	"mise.configureExtensionsUseSymLinks": true,
 	"debug.javascript.defaultRuntimeExecutable": {
 		"pwa-node": "${workspaceFolder}\\.vscode\\mise-tools\\node"
 	},
 
+	// Options for GitHub Copilot
 	"github.copilot.chat.commitMessageGeneration.instructions": [
 		{
 			"file": ".github/commit-instructions.md"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,12 @@
 _.path = [ '{{config_root}}/node_modules/.bin' ]
 _.file = { path = ".env", redact = true }
 
+[hooks]
+postinstall = "npx corepack enable"
+
+[settings]
+experimental = true
+
 [tools]
 "ubi:blake-mealey/mantle" = "0.11.17-prerelease"
 "ubi:jacktabscode/asphalt" = "0.9.1"


### PR DESCRIPTION
We can enable corepack with the mise `postinstall` hook, so these references aren't needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- CI
  - Updated development and release pipelines to use direct PNPM commands; no behavioral changes expected in builds.
- Chores
  - Simplified Git hooks to run with PNPM directly, improving consistency for commit checks and linting.
- Developer Experience
  - Added an editor setting to improve extension symlink handling.
  - Introduced environment manager settings, including a postinstall step and experimental features, to streamline local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->