### PR TITLE
📝 docs: update caution and note sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 
 </div>
 
-> [!CAUTION] You likely do not need a fully managed rojo project. For the vast
+> [!CAUTION] 
+> You likely do not need a fully managed rojo project. For the vast
 > majority of projects, a more simple setup will suffice. If you are new to
 > roblox-ts, I would strongly advise against using the vast majority of the
 > tooling in this project. Instead, I would recommend starting with a more
@@ -35,7 +36,8 @@ initiating new projects, complete with frequently used patterns that I adopt
 already configured. Additionally, it integrates my own customized eslint-config,
 which is a highly opinionated guide for writing clean and consistent code.
 
-> [!NOTE] This aims to be a fully-fledged solution to fully managed rojo
+> [!NOTE] 
+> This aims to be a fully-fledged solution to fully managed rojo
 > projects but does not currently have any built-in support for handing models.
 > Eventually this functionality will exist. For now, you can investigate
 > [Lune](https://lune-org.github.io/docs) to figure out solutions that will work

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ which is a highly opinionated guide for writing clean and consistent code.
 <!-- prettier-ignore -->
 > [!NOTE]
 > This aims to be a fully-fledged solution to fully managed rojo projects but
-> does not currently have any built-in support for handing models.  
+> does not currently have any built-in support for handling models.  
 > Eventually this functionality will exist. For now, you can investigate
 > [Lune](https://lune-org.github.io/docs) to figure out solutions that will work
 > for your use case.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 
 </div>
 
-> [!CAUTION] 
+<!-- prettier-ignore -->
+> [!CAUTION]
 > You likely do not need a fully managed rojo project. For the vast
 > majority of projects, a more simple setup will suffice. If you are new to
 > roblox-ts, I would strongly advise against using the vast majority of the
@@ -36,9 +37,10 @@ initiating new projects, complete with frequently used patterns that I adopt
 already configured. Additionally, it integrates my own customized eslint-config,
 which is a highly opinionated guide for writing clean and consistent code.
 
-> [!NOTE] 
-> This aims to be a fully-fledged solution to fully managed rojo
-> projects but does not currently have any built-in support for handing models.
+<!-- prettier-ignore -->
+> [!NOTE]
+> This aims to be a fully-fledged solution to fully managed rojo projects but
+> does not currently have any built-in support for handing models.  
 > Eventually this functionality will exist. For now, you can investigate
 > [Lune](https://lune-org.github.io/docs) to figure out solutions that will work
 > for your use case.


### PR DESCRIPTION
- On GitHub, the alerts in the README does not show up correctly. 
- This PR fixes this problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved README presentation: converted standalone CAUTION and NOTE admonitions to blockquote-style formatting and adjusted line breaks for clearer display.
  * Fixed a wording typo in the NOTE section ("handing models" → "handling models").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->